### PR TITLE
Add Render deployment configuration

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,5 @@
-﻿using DotNetEnv;
+using DotNetEnv;
+using Microsoft.AspNetCore.Http;
 using Serilog;
 using MercadinhoSaoGeraldo.Api.Infrastructure;
 
@@ -16,5 +17,11 @@ ServiceRegistration.AddAppServices(builder.Services, builder.Configuration);
 var app = builder.Build();
 
 AppPipeline.Use(app, builder.Configuration);
+
+app.MapGet("/ping", () =>
+        Results.Json(new { status = "ok", service = "Mercadinho API" }))
+    .WithName("Ping")
+    .WithTags("Health")
+    .WithOpenApi();
 
 app.Run();

--- a/README.md
+++ b/README.md
@@ -61,7 +61,28 @@ dotnet build
 dotnet run
 ```
 
-Por padrão sobe em **http://localhost:5000**.  
+Por padrão sobe em **http://localhost:5000**.
+
+---
+
+## ☁️ Deploy no Render
+
+1. Crie (ou reutilize) um serviço **Web Service** no [Render](https://render.com) apontando para este repositório.
+2. Se preferir a automação, utilize o arquivo [`render.yaml`](render.yaml) deste projeto para criar o serviço via **Blueprint** (`render blueprint deploy`). Ele já informa:
+   - uso do `Dockerfile` e do `entrypoint.sh` existentes;
+   - verificação de saúde em `GET /ping`;
+   - variáveis de ambiente esperadas (configure-as como **Secrets** antes do deploy).
+3. Configure os secrets listados abaixo com os mesmos valores utilizados no `.env` local:
+   - `SUPABASE_URL`
+   - `SUPABASE_SERVICE_ROLE_KEY`
+   - `SUPABASE_DB_CONNECTION`
+   - `JWT_ISSUER`
+   - `JWT_AUDIENCE`
+   - `JWT_KEY`
+   - `AES_KEY_BASE64`
+   - (`opcional`) `USE_HTTPS_REDIRECT`
+4. No Render, a variável `PORT` é fornecida automaticamente; o container já publica a API em `0.0.0.0:$PORT` através do `entrypoint.sh`.
+5. Após o deploy, utilize o endpoint `/ping` para confirmar que a aplicação está saudável (o Render também usará essa rota no health check).
 
 ---
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,31 @@
+services:
+  - type: web
+    name: mercadinho-sao-geraldo-api
+    env: docker
+    plan: starter
+    region: oregon
+    autoDeploy: true
+    dockerfilePath: ./Dockerfile
+    dockerContext: .
+    healthCheckPath: /ping
+    envVars:
+      - key: ASPNETCORE_ENVIRONMENT
+        value: Production
+      - key: DOTNET_EnableDiagnostics
+        value: "0"
+      - key: SUPABASE_URL
+        fromSecret: mercadinho-supabase-url
+      - key: SUPABASE_SERVICE_ROLE_KEY
+        fromSecret: mercadinho-supabase-service-role-key
+      - key: SUPABASE_DB_CONNECTION
+        fromSecret: mercadinho-supabase-db-connection
+      - key: JWT_ISSUER
+        fromSecret: mercadinho-jwt-issuer
+      - key: JWT_AUDIENCE
+        fromSecret: mercadinho-jwt-audience
+      - key: JWT_KEY
+        fromSecret: mercadinho-jwt-key
+      - key: AES_KEY_BASE64
+        fromSecret: mercadinho-aes-key-base64
+      - key: USE_HTTPS_REDIRECT
+        value: "false"


### PR DESCRIPTION
## Summary
- expose a /ping health check endpoint for container probes
- add a Render blueprint with the expected environment variables and Docker config
- document the Render deployment workflow in the README

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8f8f805083309bbe6b25c52dff05