### PR TITLE
Fix missing OpenAPI dependency for WithOpenApi extension

### DIFF
--- a/MercadinhoSaoGeraldo.Api.csproj
+++ b/MercadinhoSaoGeraldo.Api.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,6 @@
 using DotNetEnv;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OpenApi;
 using Serilog;
 using MercadinhoSaoGeraldo.Api.Infrastructure;
 


### PR DESCRIPTION
## Summary
- add Microsoft.AspNetCore.OpenApi package to enable Minimal API WithOpenApi extension
- import the corresponding namespace in Program.cs so the extension method is available

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d6677bce0c8330a89438d2243f3153