### PR TITLE
Fix entrypoint auto-detection of application DLL

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,10 +4,14 @@ set -e
 export ASPNETCORE_URLS="http://0.0.0.0:${PORT:-5000}"
 echo "Starting API on $ASPNETCORE_URLS"
 
-# Permite forçar o nome do DLL via APP_DLL, senão pega o primeiro *.dll
+# Permite forçar o nome do DLL via APP_DLL, senão tenta descobrir a partir do *.runtimeconfig.json
 APP_DLL="${APP_DLL:-}"
 if [ -z "$APP_DLL" ]; then
-  APP_DLL="$(ls -1 *.dll | head -n 1)"
+  if runtimeconfig="$(ls -1 *.runtimeconfig.json 2>/dev/null | head -n 1)" && [ -n "$runtimeconfig" ]; then
+    APP_DLL="${runtimeconfig%.runtimeconfig.json}.dll"
+  else
+    APP_DLL="$(ls -1 *.dll | head -n 1)"
+  fi
 fi
 echo "Launching: dotnet $APP_DLL"
 exec dotnet "$APP_DLL"


### PR DESCRIPTION
## Summary
- improve the entrypoint script so it prefers the DLL that matches the available runtimeconfig file
- fall back to the previous behaviour when no runtimeconfig file exists

## Testing
- dotnet build *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d668d80200833082a10ef8f04727bb