### PR TITLE
Validate JWT key length and document minimum requirement

### DIFF
--- a/Infrastructure/ServiceRegistration.cs
+++ b/Infrastructure/ServiceRegistration.cs
@@ -35,6 +35,11 @@ public static class ServiceRegistration
         var issuer = AppConfig.Require(cfg, "JWT_ISSUER");
         var audience = AppConfig.Require(cfg, "JWT_AUDIENCE");
         var jwtKey = AppConfig.Require(cfg, "JWT_KEY");
+        var jwtKeyByteCount = Encoding.UTF8.GetByteCount(jwtKey);
+        if (jwtKeyByteCount < 16)
+        {
+            throw new InvalidOperationException("JWT_KEY must be at least 128 bits (16 bytes) when encoded as UTF-8. Consider using a 32-byte key similar to AES-256.");
+        }
         services.AddSingleton(new JwtService(issuer, audience, jwtKey));
 
         services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ JWT_ISSUER=mercadinho-api
 JWT_AUDIENCE=mercadinho-clients
 JWT_KEY=uma-chave-aleatoria-bem-grande-para-jwt
 
+# A chave JWT deve ter pelo menos 128 bits (16 bytes) em UTF-8.
+# Recomenda-se utilizar 32 bytes para compatibilidade com AES-256.
+
 # Criptografia AES-256 (Base64 de 32 bytes)
 AES_KEY_BASE64=GERADO_EM_BASE64_DE_32_BYTES
 ```


### PR DESCRIPTION
## Summary
- validate the JWT_KEY length during service registration to ensure at least 128 bits in UTF-8
- advise using a 32-byte key similar to AES-256 when the key is too short
- document the minimum JWT key size requirement in the README for environment setup

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d66d32943483309861f2dac2a2be6d